### PR TITLE
:recycle: Remove deprecated .exact 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
       targets: ["TCALogsSheetKit"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .exact("0.40.2")),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "0.40.2"),
     .package(url: "https://github.com/riiid/LogsSheetKit", from: "1.0.0")
   ],
   targets: [


### PR DESCRIPTION
.exact case is deprecated, changed to:
package(url:exact:)

https://developer.apple.com/documentation/packagedescription/package/dependency/package(url:exact:)

https://developer.apple.com/documentation/packagedescription/package/dependency/requirement-swift.enum/exact(_:)